### PR TITLE
fix(postgres): Emit correct types for pg_catalog types

### DIFF
--- a/src/drivers/pg.ts
+++ b/src/drivers/pg.ts
@@ -7,8 +7,14 @@ export function columnType(column?: Column): TypeNode {
   if (column === undefined || column.type === undefined) {
     return factory.createKeywordTypeNode(SyntaxKind.AnyKeyword);
   }
+  // Some of the type names have the `pgcatalog.` prefix. Remove this.
+  let typeName = column.type.name;
+  const pgCatalog = "pg_catalog.";
+  if (typeName.startsWith(pgCatalog)) {
+    typeName = typeName.slice(pgCatalog.length);
+  }
   let typ: TypeNode = factory.createKeywordTypeNode(SyntaxKind.StringKeyword);
-  switch (column.type.name) {
+  switch (typeName) {
     case "aclitem": {
       // string
       break;

--- a/src/drivers/postgres.ts
+++ b/src/drivers/postgres.ts
@@ -2,13 +2,20 @@ import { SyntaxKind, NodeFlags, TypeNode, factory } from "typescript";
 
 import { Parameter, Column } from "../gen/plugin/codegen_pb";
 import { argName } from "./utlis";
+import { log } from "../logger";
 
 export function columnType(column?: Column): TypeNode {
   if (column === undefined || column.type === undefined) {
     return factory.createKeywordTypeNode(SyntaxKind.AnyKeyword);
   }
+  // Some of the type names have the `pgcatalog.` prefix. Remove this.
+  let typeName = column.type.name;
+  const pgCatalog = "pg_catalog.";
+  if (typeName.startsWith(pgCatalog)) {
+    typeName = typeName.slice(pgCatalog.length);
+  }
   let typ: TypeNode = factory.createKeywordTypeNode(SyntaxKind.StringKeyword);
-  switch (column.type.name) {
+  switch (typeName) {
     case "aclitem": {
       // string
       break;
@@ -228,6 +235,10 @@ export function columnType(column?: Column): TypeNode {
     }
     case "xml": {
       // string
+      break;
+    }
+    default: {
+      log(`unknown type ${column.type?.name}`);
       break;
     }
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,10 @@
+// I cant' get this import to work locally. The import in node_modules is
+// javy/dist but esbuild requires the import to be javy/fs
+//
+// @ts-expect-error
+import { readFileSync, writeFileSync, STDIO } from "javy/fs";
+
+export function log(msg: string) {
+  const encoder = new TextEncoder();
+  writeFileSync(STDIO.Stderr, encoder.encode(msg));
+}


### PR DESCRIPTION
The type name for columns and arguments is not the same. The `pg_catalog.` prefix is sometimes added to the name. Remove that before the switch statement.

Fixes #3 