### PR TITLE
feat: Experimental support for Node.js and `better-sqlite3`

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,3 +311,24 @@ sql:
       runtime: node
       driver: mysql2 # npm package name
 ```
+
+### SQLite and better-sqlite3 (Beta)
+
+```yaml
+version: '2'
+plugins:
+- name: ts
+  wasm:
+    url: https://downloads.sqlc.dev/plugin/sqlc-gen-typescript_0.1.3.wasm
+    sha256: 287df8f6cc06377d67ad5ba02c9e0f00c585509881434d15ea8bd9fc751a9368
+sql:
+- schema: "schema.sql"
+  queries: "query.sql"
+  engine: sqlite
+  codegen:
+  - out: db
+    plugin: ts
+    options:
+      runtime: node
+      driver: better-sqlite3 # npm package name
+```

--- a/examples/authors/sqlite/query.sql
+++ b/examples/authors/sqlite/query.sql
@@ -1,0 +1,18 @@
+-- name: GetAuthor :one
+SELECT * FROM authors
+WHERE id = ? LIMIT 1;
+
+-- name: ListAuthors :many
+SELECT * FROM authors
+ORDER BY name;
+
+-- name: CreateAuthor :exec
+INSERT INTO authors (
+  name, bio
+) VALUES (
+  ?, ?
+);
+
+-- name: DeleteAuthor :exec
+DELETE FROM authors
+WHERE id = ?;

--- a/examples/authors/sqlite/schema.sql
+++ b/examples/authors/sqlite/schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE authors (
+  id   INTEGER PRIMARY KEY AUTOINCREMENT,
+  name text      NOT NULL,
+  bio  text
+);

--- a/examples/node-better-sqlite3/package-lock.json
+++ b/examples/node-better-sqlite3/package-lock.json
@@ -1,0 +1,486 @@
+{
+  "name": "node-better-sqlite3",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "node-better-sqlite3",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "better-sqlite3": "^9.4.1"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.9",
+        "typescript": "^5.2.2"
+      }
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.9",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.9.tgz",
+      "integrity": "sha512-FvktcujPDj9XKMJQWFcl2vVl7OdRIqsSRX9b0acWwTmwLK9CF2eqo/FRcmMLNpugKoX/avA6pb7TorDLmpgTnQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.11.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.17.tgz",
+      "integrity": "sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/better-sqlite3": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.4.1.tgz",
+      "integrity": "sha512-QpqiQeMI4WkE+dQ68zTMX5OzlPGc7lXIDP1iKUt4Omt9PdaVgzKYxHIJRIzt1E+RUBQoFmkip/IbvzyrxehAIg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
+    "node_modules/napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+    },
+    "node_modules/node-abi": {
+      "version": "3.54.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.54.0.tgz",
+      "integrity": "sha512-p7eGEiQil0YUV3ItH4/tBb781L5impVmmx2E9FRKF7d18XXzp4PGT2tdYMFY6wQqgxD0IwNZOiSJ0/K0fSi/OA==",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    }
+  }
+}

--- a/examples/node-better-sqlite3/package.json
+++ b/examples/node-better-sqlite3/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "node-better-sqlite3",
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.9",
+    "typescript": "^5.2.2"
+  },
+  "dependencies": {
+    "better-sqlite3": "^9.4.1"
+  }
+}

--- a/examples/node-better-sqlite3/src/db/query_sql.ts
+++ b/examples/node-better-sqlite3/src/db/query_sql.ts
@@ -1,0 +1,71 @@
+import { Database } from "better-sqlite3";
+
+export const getAuthorQuery = `-- name: GetAuthor :one
+SELECT id, name, bio FROM authors
+WHERE id = ? LIMIT 1`;
+
+export interface GetAuthorArgs {
+    id: any;
+}
+
+export interface GetAuthorRow {
+    id: any;
+    name: any;
+    bio: any | null;
+}
+
+export async function getAuthor(database: Database, args: GetAuthorArgs): Promise<GetAuthorRow | null> {
+    const stmt = database.prepare(getAuthorQuery);
+    const result = await stmt.get(args.id);
+    if (result == undefined) {
+        return null;
+    }
+    return result as GetAuthorRow;
+}
+
+export const listAuthorsQuery = `-- name: ListAuthors :many
+SELECT id, name, bio FROM authors
+ORDER BY name`;
+
+export interface ListAuthorsRow {
+    id: any;
+    name: any;
+    bio: any | null;
+}
+
+export async function listAuthors(database: Database): Promise<ListAuthorsRow[]> {
+    const stmt = database.prepare(listAuthorsQuery);
+    const result = await stmt.all();
+    return result as ListAuthorsRow[];
+}
+
+export const createAuthorQuery = `-- name: CreateAuthor :exec
+INSERT INTO authors (
+  name, bio
+) VALUES (
+  ?, ?
+)`;
+
+export interface CreateAuthorArgs {
+    name: any;
+    bio: any | null;
+}
+
+export async function createAuthor(database: Database, args: CreateAuthorArgs): Promise<void> {
+    const stmt = database.prepare(createAuthorQuery);
+    await stmt.run(args.name, args.bio);
+}
+
+export const deleteAuthorQuery = `-- name: DeleteAuthor :exec
+DELETE FROM authors
+WHERE id = ?`;
+
+export interface DeleteAuthorArgs {
+    id: any;
+}
+
+export async function deleteAuthor(database: Database, args: DeleteAuthorArgs): Promise<void> {
+    const stmt = database.prepare(deleteAuthorQuery);
+    await stmt.run(args.id);
+}
+

--- a/examples/node-better-sqlite3/src/main.ts
+++ b/examples/node-better-sqlite3/src/main.ts
@@ -1,0 +1,54 @@
+import Database from "better-sqlite3";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import {
+  createAuthor,
+  deleteAuthor,
+  getAuthor,
+  listAuthors,
+} from "./db/query_sql";
+
+interface Author {
+  id: string;
+  name: string;
+  bio: string | null;
+}
+
+async function main() {
+  const ddl = await readFile(join(__dirname, "../../authors/sqlite/schema.sql"), { encoding: 'utf-8' });
+  const database = new Database(":memory:");
+
+  // Create tables
+  database.exec(ddl);
+
+  // Create an author
+  await createAuthor(database, {
+    name: "Seal",
+    bio: "Kissed from a rose",
+  });
+
+  // List the authors
+  const authors = await listAuthors(database);
+  console.log(authors);
+
+  // Get that author
+  const seal = await getAuthor(database, { id: authors[0].id });
+  if (seal === null) {
+    throw new Error("seal not found");
+  }
+  console.log(seal);
+
+  // Delete the author
+  await deleteAuthor(database, { id: seal.id });
+}
+
+(async () => {
+  try {
+    await main();
+    process.exit(0);
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+})();

--- a/examples/node-better-sqlite3/tsconfig.json
+++ b/examples/node-better-sqlite3/tsconfig.json
@@ -1,0 +1,109 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  }
+}

--- a/examples/sqlc.dev.yaml
+++ b/examples/sqlc.dev.yaml
@@ -58,3 +58,12 @@ sql:
     options:
       runtime: bun
       driver: mysql2
+- schema: "authors/sqlite/schema.sql"
+  queries: "authors/sqlite/query.sql"
+  engine: "sqlite"
+  codegen:
+  - plugin: ts
+    out: node-better-sqlite3/src/db
+    options:
+      runtime: node
+      driver: better-sqlite3

--- a/src/app.ts
+++ b/src/app.ts
@@ -28,6 +28,7 @@ import {
 } from "./gen/plugin/codegen_pb";
 
 import { argName, colName } from "./drivers/utlis";
+import betterSQLite3 from "./drivers/better-sqlite3";
 import pg from "./drivers/pg";
 import postgres from "./drivers/postgres";
 import mysql2 from "./drivers/mysql2";
@@ -81,6 +82,9 @@ function createNodeGenerator(driver?: string): Driver {
     }
     case "postgres": {
       return postgres;
+    }
+    case "better-sqlite3": {
+      return betterSQLite3;
     }
   }
   throw new Error(`unknown driver: ${driver}`);

--- a/src/drivers/better-sqlite3.ts
+++ b/src/drivers/better-sqlite3.ts
@@ -1,0 +1,436 @@
+import { SyntaxKind, NodeFlags, Node, TypeNode, factory } from "typescript";
+
+import { Parameter, Column, Query } from "../gen/plugin/codegen_pb";
+import { argName } from "./utlis";
+
+/**
+ * {@link https://github.com/WiseLibs/better-sqlite3/blob/v9.4.1/docs/api.md#binding-parameters}
+ * {@link https://github.com/sqlc-dev/sqlc/blob/v1.25.0/internal/codegen/golang/sqlite_type.go}
+ */
+export function columnType(column?: Column): TypeNode {
+  if (column === undefined || column.type === undefined) {
+    return factory.createKeywordTypeNode(SyntaxKind.AnyKeyword);
+  }
+
+  let typ: TypeNode = factory.createKeywordTypeNode(SyntaxKind.AnyKeyword);
+  switch (column.type.name) {
+    case "int":
+    case "integer":
+    case "tinyint":
+    case "smallint":
+    case "mediumint":
+    case "bigint":
+    case "unsignedbigint":
+    case "int2":
+    case "int8": {
+      // TODO: Improve `BigInt` handling (https://github.com/WiseLibs/better-sqlite3/blob/v9.4.1/docs/integer.md)
+      typ = factory.createKeywordTypeNode(SyntaxKind.NumberKeyword);
+      break;
+    }
+    case "blob": {
+      // TODO: Is this correct or node-specific?
+      typ = factory.createTypeReferenceNode(
+        factory.createIdentifier("Buffer"),
+        undefined
+      );
+      break;
+    }
+    case "real":
+    case "double":
+    case "doubleprecision":
+    case "float": {
+      typ = factory.createKeywordTypeNode(SyntaxKind.NumberKeyword);
+      break;
+    }
+    case "boolean":
+    case "bool": {
+      typ = factory.createKeywordTypeNode(SyntaxKind.BooleanKeyword);
+      break;
+    }
+    case "date":
+    case "datetime":
+    case "timestamp": {
+      typ = factory.createTypeReferenceNode(
+        factory.createIdentifier("Date"),
+        undefined
+      );
+      break;
+    }
+  }
+
+  if (column.notNull) {
+    return typ;
+  }
+
+  return factory.createUnionTypeNode([
+    typ,
+    factory.createLiteralTypeNode(factory.createNull()),
+  ]);
+}
+
+export function preamble(queries: Query[]) {
+  const imports: Node[] = [
+    factory.createImportDeclaration(
+      undefined,
+      factory.createImportClause(
+        false,
+        undefined,
+        factory.createNamedImports([
+          factory.createImportSpecifier(
+            false,
+            undefined,
+            factory.createIdentifier("Database")
+          ),
+        ])
+      ),
+      factory.createStringLiteral("better-sqlite3"),
+      undefined
+    ),
+  ];
+
+  return imports;
+}
+
+function funcParamsDecl(iface: string | undefined, params: Parameter[]) {
+  let funcParams = [
+    factory.createParameterDeclaration(
+      undefined,
+      undefined,
+      factory.createIdentifier("database"),
+      undefined,
+      factory.createTypeReferenceNode(
+        factory.createIdentifier("Database"),
+        undefined
+      ),
+      undefined
+    ),
+  ];
+
+  if (iface && params.length > 0) {
+    funcParams.push(
+      factory.createParameterDeclaration(
+        undefined,
+        undefined,
+        factory.createIdentifier("args"),
+        undefined,
+        factory.createTypeReferenceNode(
+          factory.createIdentifier(iface),
+          undefined
+        ),
+        undefined
+      )
+    );
+  }
+
+  return funcParams;
+}
+
+export function execDecl(
+  funcName: string,
+  queryName: string,
+  argIface: string | undefined,
+  params: Parameter[]
+) {
+  const funcParams = funcParamsDecl(argIface, params);
+
+  return factory.createFunctionDeclaration(
+    [
+      factory.createToken(SyntaxKind.ExportKeyword),
+      factory.createToken(SyntaxKind.AsyncKeyword),
+    ],
+    undefined,
+    factory.createIdentifier(funcName),
+    undefined,
+    funcParams,
+    factory.createTypeReferenceNode(factory.createIdentifier("Promise"), [
+      factory.createKeywordTypeNode(SyntaxKind.VoidKeyword),
+    ]),
+    factory.createBlock(
+      [
+        factory.createVariableStatement(
+          undefined,
+          factory.createVariableDeclarationList(
+            [
+              factory.createVariableDeclaration(
+                factory.createIdentifier("stmt"),
+                undefined,
+                undefined,
+                factory.createCallExpression(
+                  factory.createPropertyAccessExpression(
+                    factory.createIdentifier("database"),
+                    factory.createIdentifier("prepare")
+                  ),
+                  undefined,
+                  [
+                    factory.createIdentifier(queryName)
+                  ]
+                )
+              ),
+            ],
+            NodeFlags.Const |
+            // ts.NodeFlags.Constant |
+            // NodeFlags.AwaitContext |
+            // ts.NodeFlags.Constant |
+            // NodeFlags.ContextFlags |
+            NodeFlags.TypeExcludesFlags
+          )
+        ),
+        factory.createExpressionStatement(
+          factory.createAwaitExpression(
+            factory.createCallExpression(
+              factory.createPropertyAccessExpression(
+                factory.createIdentifier("stmt"),
+                factory.createIdentifier("run")
+              ),
+              undefined,
+              params.map((param, i) =>
+                factory.createPropertyAccessExpression(
+                  factory.createIdentifier("args"),
+                  factory.createIdentifier(argName(i, param.column))
+                )
+              ),
+            )
+          )
+        ),
+      ],
+      true
+    )
+  );
+}
+
+export function oneDecl(
+  funcName: string,
+  queryName: string,
+  argIface: string | undefined,
+  returnIface: string,
+  params: Parameter[],
+  columns: Column[]
+) {
+  const funcParams = funcParamsDecl(argIface, params);
+
+  return factory.createFunctionDeclaration(
+    [
+      factory.createToken(SyntaxKind.ExportKeyword),
+      factory.createToken(SyntaxKind.AsyncKeyword),
+    ],
+    undefined,
+    factory.createIdentifier(funcName),
+    undefined,
+    funcParams,
+    factory.createTypeReferenceNode(factory.createIdentifier("Promise"), [
+      factory.createUnionTypeNode([
+        factory.createTypeReferenceNode(
+          factory.createIdentifier(returnIface),
+          undefined
+        ),
+        factory.createLiteralTypeNode(factory.createNull()),
+      ]),
+    ]),
+    factory.createBlock(
+      [
+        factory.createVariableStatement(
+          undefined,
+          factory.createVariableDeclarationList(
+            [
+              factory.createVariableDeclaration(
+                factory.createIdentifier("stmt"),
+                undefined,
+                undefined,
+                factory.createCallExpression(
+                  factory.createPropertyAccessExpression(
+                    factory.createIdentifier("database"),
+                    factory.createIdentifier("prepare")
+                  ),
+                  undefined,
+                  [
+                    factory.createIdentifier(queryName)
+                  ]
+                )
+              ),
+            ],
+            NodeFlags.Const |
+            // ts.NodeFlags.Constant |
+            // NodeFlags.AwaitContext |
+            // ts.NodeFlags.Constant |
+            // NodeFlags.ContextFlags |
+            NodeFlags.TypeExcludesFlags
+          )
+        ),
+        factory.createVariableStatement(
+          undefined,
+          factory.createVariableDeclarationList(
+            [
+              factory.createVariableDeclaration(
+                factory.createIdentifier("result"),
+                undefined,
+                undefined,
+                factory.createAwaitExpression(
+                  factory.createCallExpression(
+                    factory.createPropertyAccessExpression(
+                      factory.createIdentifier("stmt"),
+                      factory.createIdentifier("get")
+                    ),
+                    undefined,
+                    params.map((param, i) =>
+                      factory.createPropertyAccessExpression(
+                        factory.createIdentifier("args"),
+                        factory.createIdentifier(
+                          argName(i, param.column)
+                        )
+                      )
+                    ),
+                  )
+                )
+              ),
+            ],
+            NodeFlags.Const |
+            // ts.NodeFlags.Constant |
+            NodeFlags.AwaitContext |
+            // ts.NodeFlags.Constant |
+            NodeFlags.ContextFlags |
+            NodeFlags.TypeExcludesFlags
+          )
+        ),
+        factory.createIfStatement(
+          factory.createBinaryExpression(
+            factory.createIdentifier("result"),
+            factory.createToken(SyntaxKind.EqualsEqualsToken),
+            factory.createIdentifier("undefined")
+          ),
+          factory.createBlock(
+            [factory.createReturnStatement(factory.createNull())],
+            true
+          ),
+          undefined
+        ),
+        factory.createReturnStatement(
+          factory.createAsExpression(
+            factory.createIdentifier("result"),
+            factory.createTypeReferenceNode(
+              factory.createIdentifier(returnIface),
+              undefined
+            )
+          )
+        ),
+      ],
+      true
+    )
+  );
+}
+
+export function manyDecl(
+  funcName: string,
+  queryName: string,
+  argIface: string | undefined,
+  returnIface: string,
+  params: Parameter[],
+  columns: Column[]
+) {
+  const funcParams = funcParamsDecl(argIface, params);
+
+  return factory.createFunctionDeclaration(
+    [
+      factory.createToken(SyntaxKind.ExportKeyword),
+      factory.createToken(SyntaxKind.AsyncKeyword),
+    ],
+    undefined,
+    factory.createIdentifier(funcName),
+    undefined,
+    funcParams,
+    factory.createTypeReferenceNode(factory.createIdentifier("Promise"), [
+      factory.createArrayTypeNode(
+        factory.createTypeReferenceNode(
+          factory.createIdentifier(returnIface),
+          undefined
+        )
+      ),
+    ]),
+    factory.createBlock(
+      [
+        factory.createVariableStatement(
+          undefined,
+          factory.createVariableDeclarationList(
+            [
+              factory.createVariableDeclaration(
+                factory.createIdentifier("stmt"),
+                undefined,
+                undefined,
+                factory.createCallExpression(
+                  factory.createPropertyAccessExpression(
+                    factory.createIdentifier("database"),
+                    factory.createIdentifier("prepare")
+                  ),
+                  undefined,
+                  [
+                    factory.createIdentifier(queryName)
+                  ]
+                )
+              ),
+            ],
+            NodeFlags.Const |
+            // ts.NodeFlags.Constant |
+            // NodeFlags.AwaitContext |
+            // ts.NodeFlags.Constant |
+            // NodeFlags.ContextFlags |
+            NodeFlags.TypeExcludesFlags
+          )
+        ),
+        factory.createVariableStatement(
+          undefined,
+          factory.createVariableDeclarationList(
+            [
+              factory.createVariableDeclaration(
+                factory.createIdentifier("result"),
+                undefined,
+                undefined,
+                factory.createAwaitExpression(
+                  factory.createCallExpression(
+                    factory.createPropertyAccessExpression(
+                      factory.createIdentifier("stmt"),
+                      factory.createIdentifier("all")
+                    ),
+                    undefined,
+                    params.map((param, i) =>
+                      factory.createPropertyAccessExpression(
+                        factory.createIdentifier("args"),
+                        factory.createIdentifier(
+                          argName(i, param.column)
+                        )
+                      )
+                    ),
+                  )
+                )
+              ),
+            ],
+            NodeFlags.Const |
+            // NodeFlags.Constant |
+            NodeFlags.AwaitContext |
+            // NodeFlags.Constant |
+            NodeFlags.ContextFlags |
+            NodeFlags.TypeExcludesFlags
+          )
+        ),
+        factory.createReturnStatement(
+          factory.createAsExpression(
+            factory.createIdentifier("result"),
+            factory.createArrayTypeNode(
+              factory.createTypeReferenceNode(
+                factory.createIdentifier(returnIface),
+                undefined
+              )
+            )
+          )
+        ),
+      ],
+      true
+    )
+  );
+}
+
+export default {
+  columnType,
+  execDecl,
+  manyDecl,
+  oneDecl,
+  preamble,
+};


### PR DESCRIPTION
Hi, thanks for the great project! I'd like to use `sqlc-gen-typescript` and `sqlite` together.  So this PR experimentally adds support for Node.js and [better-sqlite3](https://github.com/WiseLibs/better-sqlite3). Please let me know if there are any errors or room for improvement!

**Summary:**

- Added `src/drivers/better-sqlite3.ts` based on https://github.com/sqlc-dev/sqlc/blob/v1.25.0/internal/codegen/golang/sqlite_type.go
  - Sufficient testing has not yet been done
  - There is still room for improvement in the handling of `Bigint` (https://github.com/WiseLibs/better-sqlite3/blob/v9.4.1/docs/api.md#binding-parameters), but I just haven't come up with a good way to do this.
- Added `examples/node-better-sqlite3` to test code generation

---

Related to #5