### PR TITLE
[Fix] Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ plugins:
 sql:
 - schema: "schema.sql"
   queries: "query.sql"
-  engine: postgresql
+  engine: "mysql"
   codegen:
   - out: db
     plugin: ts


### PR DESCRIPTION
# Bug Fix

Initially the engine is `postgresql` even for `mysql`. As a result when I tried to compile, it led to issue #25. However, when I tried to replace the `$1` placeholder in the queries file with `?` as per mysql placeholder format, the code failed to compile due to the engine being `postgresql` compiler unable to read mysql syntax.

## Problem

The engine in yaml for mysql is incorrect.

## Solution

Updating the README to replace the engine with `mysql` for greater clarity and correctness