### PR TITLE
make `sqlc.yaml` copy/pastable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Initialize a new package.
 $ bun init
 ```
 
-sqlc looks for either a `sqlc.(yaml|yml)` or `sqlc.json` file in the current
+sqlc looks for either a `sqlc.yaml`, `sqlc.yml` or `sqlc.json` file in the current
 directory. In our new directory, create a file named `sqlc.yaml` with the
 following contents:
 


### PR DESCRIPTION
Having `sqlc.(yaml|yml)` almost takes up as many characters on the page as it saves, but more importantly, it makes it so that I can't just copy `sqlc.yaml` (or `sqlc.yml`) and get to work.

This change enumerates the two to simplify reading, search indexing, and copying of the filename.