### PR TITLE
feat: Support generating function comments

### DIFF
--- a/examples/authors/mysql/query.sql
+++ b/examples/authors/mysql/query.sql
@@ -7,6 +7,7 @@ SELECT * FROM authors
 ORDER BY name;
 
 /* name: CreateAuthor :exec */
+/* Create a new author. */
 INSERT INTO authors (
   name, bio
 ) VALUES (

--- a/examples/authors/postgresql/query.sql
+++ b/examples/authors/postgresql/query.sql
@@ -7,6 +7,9 @@ SELECT * FROM authors
 ORDER BY name;
 
 -- name: CreateAuthor :one
+-- Create a new author.
+-- This is the second line.*/
+--/This is the third line.
 INSERT INTO authors (
   name, bio
 ) VALUES (

--- a/examples/authors/sqlite/query.sql
+++ b/examples/authors/sqlite/query.sql
@@ -7,6 +7,7 @@ SELECT * FROM authors
 ORDER BY name;
 
 -- name: CreateAuthor :exec
+-- Create a new author.
 INSERT INTO authors (
   name, bio
 ) VALUES (

--- a/examples/bun-mysql2/src/db/query_sql.ts
+++ b/examples/bun-mysql2/src/db/query_sql.ts
@@ -72,6 +72,9 @@ export interface CreateAuthorArgs {
     bio: string | null;
 }
 
+/**
+ * Create a new author.
+ */
 export async function createAuthor(client: Client, args: CreateAuthorArgs): Promise<void> {
     await client.query({
         sql: createAuthorQuery,

--- a/examples/bun-pg/src/db/query_sql.ts
+++ b/examples/bun-pg/src/db/query_sql.ts
@@ -81,6 +81,11 @@ export interface CreateAuthorRow {
     bio: string | null;
 }
 
+/**
+ * Create a new author.
+ * This is the second line.*\/
+ *\/This is the third line.
+ */
 export async function createAuthor(client: Client, args: CreateAuthorArgs): Promise<CreateAuthorRow | null> {
     const result = await client.query({
         text: createAuthorQuery,

--- a/examples/bun-postgres/src/db/query_sql.ts
+++ b/examples/bun-postgres/src/db/query_sql.ts
@@ -69,6 +69,11 @@ export interface CreateAuthorRow {
     bio: string | null;
 }
 
+/**
+ * Create a new author.
+ * This is the second line.*\/
+ *\/This is the third line.
+ */
 export async function createAuthor(sql: Sql, args: CreateAuthorArgs): Promise<CreateAuthorRow | null> {
     const rows = await sql.unsafe(createAuthorQuery, [args.name, args.bio]).values();
     if (rows.length !== 1) {

--- a/examples/node-better-sqlite3/src/db/query_sql.ts
+++ b/examples/node-better-sqlite3/src/db/query_sql.ts
@@ -53,6 +53,9 @@ export interface CreateAuthorArgs {
     bio: any | null;
 }
 
+/**
+ * Create a new author.
+ */
 export async function createAuthor(database: Database, args: CreateAuthorArgs): Promise<void> {
     const stmt = database.prepare(createAuthorQuery);
     await stmt.run(args.name, args.bio);

--- a/examples/node-mysql2/src/db/query_sql.ts
+++ b/examples/node-mysql2/src/db/query_sql.ts
@@ -72,6 +72,9 @@ export interface CreateAuthorArgs {
     bio: string | null;
 }
 
+/**
+ * Create a new author.
+ */
 export async function createAuthor(client: Client, args: CreateAuthorArgs): Promise<void> {
     await client.query({
         sql: createAuthorQuery,

--- a/examples/node-pg/src/db/query_sql.ts
+++ b/examples/node-pg/src/db/query_sql.ts
@@ -81,6 +81,11 @@ export interface CreateAuthorRow {
     bio: string | null;
 }
 
+/**
+ * Create a new author.
+ * This is the second line.*\/
+ *\/This is the third line.
+ */
 export async function createAuthor(client: Client, args: CreateAuthorArgs): Promise<CreateAuthorRow | null> {
     const result = await client.query({
         text: createAuthorQuery,

--- a/examples/node-postgres/src/db/query_sql.ts
+++ b/examples/node-postgres/src/db/query_sql.ts
@@ -69,6 +69,11 @@ export interface CreateAuthorRow {
     bio: string | null;
 }
 
+/**
+ * Create a new author.
+ * This is the second line.*\/
+ *\/This is the third line.
+ */
 export async function createAuthor(sql: Sql, args: CreateAuthorArgs): Promise<CreateAuthorRow | null> {
     const rows = await sql.unsafe(createAuthorQuery, [args.name, args.bio]).values();
     if (rows.length !== 1) {


### PR DESCRIPTION
This PR adds support for generating function comments like the official Go plugin does.

- https://github.com/sqlc-dev/sqlc/blob/v1.27.0/examples/ondeck/postgresql/query/city.sql#L11-L21
- https://github.com/sqlc-dev/sqlc/blob/v1.27.0/examples/ondeck/postgresql/city.sql.go#L27-L35