### PR TITLE
Add local development instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,3 +333,58 @@ sql:
       runtime: node
       driver: better-sqlite3 # npm package name
 ```
+
+## Development
+
+If you want to build and test sqlc-gen-typescript locally, follow these steps:
+
+1. Clone the repository and install dependencies:
+   ```
+   git clone https://github.com/sqlc-dev/sqlc-gen-typescript.git
+   cd sqlc-gen-typescript
+   npm install
+   ```
+
+2. Make your desired changes to the codebase. The main source files are located in the `src` directory.
+
+3. If you've made changes that require updating dependencies, run:
+   ```
+   npm install
+   ```
+
+4. Build the WASM plugin:
+   ```
+   npx tsc --noEmit
+   npx esbuild --bundle src/app.ts --tree-shaking=true --format=esm --target=es2020 --outfile=out.js
+
+   # Ensure you have Javy installed and available in your PATH
+   javy compile out.js -o examples/plugin.wasm
+   ```
+
+5. To test your local build, create a test project with a `sqlc.yaml` file containing:
+
+   ```yaml
+   version: '2'
+   plugins:
+   - name: ts
+     wasm:
+       url: file:///{path_to_your_local_wasm_file}
+       sha256: {sha256_of_your_wasm_file}
+   sql:
+   - schema: "schema.sql"
+     queries: "query.sql"
+     engine: {your_database_engine}
+     codegen:
+     - out: db
+       plugin: ts
+       options:
+         runtime: node
+         driver: {your_database_driver}
+   ```
+
+   Replace the placeholders with appropriate values for your setup.
+
+6. Run sqlc in your test project to generate TypeScript code using your local plugin build:
+   ```
+   sqlc generate
+   ```

--- a/README.md
+++ b/README.md
@@ -352,13 +352,13 @@ If you want to build and test sqlc-gen-typescript locally, follow these steps:
    npm install
    ```
 
-4. Build the WASM plugin:
+4. Build the WASM plugin:  
+Check the `Makefile` for details.
    ```
-   npx tsc --noEmit
-   npx esbuild --bundle src/app.ts --tree-shaking=true --format=esm --target=es2020 --outfile=out.js
+   make out.js
 
    # Ensure you have Javy installed and available in your PATH
-   javy compile out.js -o examples/plugin.wasm
+   make examples/plugin.wasm
    ```
 
 5. To test your local build, create a test project with a `sqlc.yaml` file containing:
@@ -368,7 +368,7 @@ If you want to build and test sqlc-gen-typescript locally, follow these steps:
    plugins:
    - name: ts
      wasm:
-       url: file:///{path_to_your_local_wasm_file}
+       url: file://{path_to_your_local_wasm_file}
        sha256: {sha256_of_your_wasm_file}
    sql:
    - schema: "schema.sql"

--- a/README.md
+++ b/README.md
@@ -388,3 +388,6 @@ Check the `Makefile` for details.
    ```
    sqlc generate
    ```
+
+For more details on sqlc development, refer to the sqlc core development guide. This guide provides additional information on setting up and working with sqlc in general, which may be useful for contributors to this project.  
+https://docs.sqlc.dev/en/latest/guides/development.html


### PR DESCRIPTION
This PR adds a new "Development" section to the README, providing step-by-step instructions for building and testing sqlc-gen-typescript locally. These additions aim to:

1. Guide developers through the process of local setup and testing
2. Lower the barrier to entry for potential contributors

By making the development process more transparent and accessible, we hope to encourage more developers to contribute to this project.