### PR TITLE
fix(better-sqlite3): Emit correct types instead of any

### DIFF
--- a/examples/node-better-sqlite3/src/db/query_sql.ts
+++ b/examples/node-better-sqlite3/src/db/query_sql.ts
@@ -7,13 +7,13 @@ SELECT id, name, bio FROM authors
 WHERE id = ? LIMIT 1`;
 
 export interface GetAuthorArgs {
-    id: any;
+    id: number;
 }
 
 export interface GetAuthorRow {
-    id: any;
-    name: any;
-    bio: any | null;
+    id: number;
+    name: string;
+    bio: string | null;
 }
 
 export async function getAuthor(database: Database, args: GetAuthorArgs): Promise<GetAuthorRow | null> {
@@ -30,9 +30,9 @@ SELECT id, name, bio FROM authors
 ORDER BY name`;
 
 export interface ListAuthorsRow {
-    id: any;
-    name: any;
-    bio: any | null;
+    id: number;
+    name: string;
+    bio: string | null;
 }
 
 export async function listAuthors(database: Database): Promise<ListAuthorsRow[]> {
@@ -49,8 +49,8 @@ INSERT INTO authors (
 )`;
 
 export interface CreateAuthorArgs {
-    name: any;
-    bio: any | null;
+    name: string;
+    bio: string | null;
 }
 
 export async function createAuthor(database: Database, args: CreateAuthorArgs): Promise<void> {
@@ -63,7 +63,7 @@ DELETE FROM authors
 WHERE id = ?`;
 
 export interface DeleteAuthorArgs {
-    id: any;
+    id: number;
 }
 
 export async function deleteAuthor(database: Database, args: DeleteAuthorArgs): Promise<void> {

--- a/src/drivers/better-sqlite3.ts
+++ b/src/drivers/better-sqlite3.ts
@@ -55,7 +55,7 @@ export class Driver {
     }
 
     let typ: TypeNode = factory.createKeywordTypeNode(SyntaxKind.AnyKeyword);
-    switch (column.type.name) {
+    switch (column.type.name.toLowerCase()) {
       case "int":
       case "integer":
       case "tinyint":
@@ -87,6 +87,11 @@ export class Driver {
       case "boolean":
       case "bool": {
         typ = factory.createKeywordTypeNode(SyntaxKind.BooleanKeyword);
+        break;
+      }
+      case "text":
+      case "varchar": {
+        typ = factory.createKeywordTypeNode(SyntaxKind.StringKeyword);
         break;
       }
       case "date":


### PR DESCRIPTION
Sqlite's driver was not generating types properly, it was returning all columns as `any` attributes instead of inferring the type from the schema.

Here's an example:

```sql
-- schema.sql
CREATE TABLE tenants (
  id TEXT PRIMARY KEY,
  name TEXT NOT NULL,
  slug TEXT NOT NULL UNIQUE,
  deleted INTEGER NOT NULL DEFAULT 0,
  company_tin TEXT NOT NULL UNIQUE
);
```
Source file:
```sql
-- name: Find :one
SELECT * FROM tenants
WHERE id = ?;
```
Generated code:
```ts
// ...

export interface FindArgs {
    id: any;
}

export interface FindRow {
    id: any;
    name: any;
    slug: any;
    deleted: any;
    companyTin: any;
}
// ...

```
When debugging the driver I noticed the received `Column` in the `columnType` method where:
```ts
const example1 = {
  name: "id",
  notNull: true,
  isArray: false,
  comment: "",
  length: -1,
  isNamedParam: false,
  isFuncCall: false,
  scope: "",
  table: { catalog: "", schema: "", name: "tenants" },
  tableAlias: "",
  type: { catalog: "", schema: "", name: "TEXT" },
  isSqlcSlice: false,
  originalName: "id",
  unsigned: false,
  arrayDims: 0,
};

const example2 = {
  name: "deleted",
  notNull: true,
  isArray: false,
  comment: "",
  length: -1,
  isNamedParam: false,
  isFuncCall: false,
  scope: "",
  table: { catalog: "", schema: "", name: "tenants" },
  tableAlias: "",
  type: { catalog: "", schema: "", name: "INTEGER" },
  isSqlcSlice: false,
  originalName: "deleted",
  unsigned: false,
  arrayDims: 0,
};
```

I decided to convert the `column.type.name` to lowercase and add `TEXT` and `VARCHAR` types to the switch case. After building the wasm module, I run it with `examples/sqlc.dev.yaml` config file and the example file got updated. 